### PR TITLE
Moved JavaScript transform panel to the bottom half

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -140,12 +140,12 @@ const App: React.FC = () => {
         </div>
       </div>
       <div id="main-panes">
-        <SplitPane split="vertical" defaultSize="35%">
-          <SourceBox source={source} sourceType={sourceType} onChangeSource={setSource} />
-          <SplitPane split="vertical" defaultSize="40%">
-            <TransformBox transform={transform} onChangeTransform={setTransform} />
+        <SplitPane split="horizontal" defaultSize="80%">
+          <SplitPane split="vertical" defaultSize="50%">
+            <SourceBox source={source} sourceType={sourceType} onChangeSource={setSource} />
             <DestBox destType={destType} result={result} />
           </SplitPane>
+          <TransformBox transform={transform} onChangeTransform={setTransform} />
         </SplitPane>
       </div>
     </>


### PR DESCRIPTION
This works better on my 13" screen and seems more familiar as UI based on browser consoles etc.
![image](https://user-images.githubusercontent.com/4352/74514692-c9657b00-4f15-11ea-9460-1d10cb6f1dc4.png)
