### PR TITLE
Add Example data button to source menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { destinationConverters, sourceConverters } from "./converters";
+import { sourceSamples } from "./samples"
 import { doTransform } from "./core";
 import { Menu, MenuItemProps } from "semantic-ui-react";
 import { TransformResult } from "./types";
@@ -35,15 +36,22 @@ interface ConverterSelectProps extends Styleable {
   value: string;
   options: string[];
   onChange: (val: string) => void;
+  onChangeSample?: () => void;
 }
 
-const ConverterSelect: React.FC<ConverterSelectProps> = ({ value, options, onChange, style }) => {
+const ConverterSelect: React.FC<ConverterSelectProps> = ({ value, options, onChange, style, onChangeSample }) => {
   const handleClick = (e: React.MouseEvent, { name }: MenuItemProps) => name && onChange(name);
+  const handleSampleClick = () => { if (onChangeSample) {onChangeSample();} };
   return (
     <Menu fluid size="mini" style={style}>
       {options.map(item => (
         <Menu.Item name={item} active={value === item} onClick={handleClick} />
       ))}
+      {onChangeSample ? (
+        <Menu.Menu position='right'>
+          <Menu.Item name='Example' title='Use example data in the selected format' onClick={handleSampleClick} />
+        </Menu.Menu>
+      ) : null }
     </Menu>
   );
 };
@@ -117,9 +125,12 @@ const DestBox: React.FC<DestProps> = ({ destType, result, style }) => {
 };
 
 const App: React.FC = () => {
+  const [sourceType, setSourceType] = React.useState("yaml");
   const [source, setSource] = React.useState("");
-  const [sourceType, setSourceType] = React.useState("text");
-  const [destType, setDestType] = React.useState("text");
+  const setSample = () => {
+    setSource(sourceSamples[sourceType])
+  }
+  const [destType, setDestType] = React.useState("json");
   const [transform, setTransform] = React.useState("");
   const result: TransformResult = React.useMemo(() => doTransform(sourceType, source, transform, destType), [
     sourceType,
@@ -132,7 +143,7 @@ const App: React.FC = () => {
       <div id="settings">
         <div>
           Input Format
-          <ConverterSelect value={sourceType} options={Object.keys(sourceConverters)} onChange={setSourceType} />
+          <ConverterSelect value={sourceType} options={Object.keys(sourceConverters)} onChange={setSourceType} onChangeSample={setSample} />
         </div>
         <div>
           Output Format

--- a/src/samples.tsx
+++ b/src/samples.tsx
@@ -1,0 +1,26 @@
+export const sourceSamples: any = {
+  "json-compact": 'json-compact',
+  csv: 'A,B,C\nOne,Two,Three\nTwo,Four,Five\nThree,Six,Seven',
+  scsv: '"A","B","C"\n"One","Two","Three"\n"Two","Four","Five"\n"Three","Six","Seven"',
+  json: JSON.stringify([
+    {
+      "A": "One",
+      "B": "Two",
+      "C": "Three"
+    },
+    {
+      "A": "Two",
+      "B": "Four",
+      "C": "Five"
+    },
+    {
+      "A": "Three",
+      "B": "Six",
+      "C": "Seven"
+    }
+  ], null, 2),
+  text: "text",
+  tsv: 'A	B	C\nOne	Two	Three\nTwo	Four	Five\nThree	Six	Seven',
+  yaml: '- A: One\n  B: Two\n  C: Three\n- A: Two\n  B: Four\n  C: Five\n- A: Three\n  B: Six\n  C: Seven',
+  toml: '# This is a TOML document.\ntitle = "TOML Example"\n[owner]\nname = "Tom Preston-Werner"\ndob = 1979-05-27T07:32:00-08:00 # First class dates'
+};


### PR DESCRIPTION
Adds an Example button to the source panel menu which when clicked sets source to example data in the selected format.﻿
![image](https://user-images.githubusercontent.com/4352/74531071-55869b00-4f34-11ea-86d6-37f717dd08b0.png)

